### PR TITLE
GPS tweaks for EKF testing

### DIFF
--- a/AirLib/include/api/RpcLibClientBase.hpp
+++ b/AirLib/include/api/RpcLibClientBase.hpp
@@ -96,29 +96,30 @@ namespace airlib
         bool isApiControlEnabled(const std::string& vehicle_name = "") const;
         void enableApiControl(bool is_enabled, const std::string& vehicle_name = "");
 
-        msr::airlib::GeoPoint getHomeGeoPoint(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::GeoPoint getHomeGeoPoint(const std::string& vehicle_name = "") const;
 
         bool simRunConsoleCommand(const std::string& command);
 
         // sensor APIs
         // sensor info
-        msr::airlib::ImuInfo getImuInfo(const std::string& vehicle_name = "") const;
-        msr::airlib::LidarInfo getLidarInfo(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::ImuInfo getImuInfo(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::LidarInfo getLidarInfo(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
 
         // sensor data 
-        msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
-        msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
-        msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
-        msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
-        msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "") const;
-        msr::airlib::DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::LidarData getLidarData(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::ImuBase::Output getImuData(const std::string& imu_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::BarometerBase::Output getBarometerData(const std::string& barometer_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::MagnetometerBase::Output getMagnetometerData(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::Vector3r getGroundTruthMagneticField(const std::string& magnetometer_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::GpsBase::Output getGpsData(const std::string& gps_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::DistanceSensorData getDistanceSensorData(const std::string& distance_sensor_name = "", const std::string& vehicle_name = "") const;
 
         // sensor buffer
-        msr::airlib::GpsDataBuffer getGpsDataBuffer(const std::string& vehicle_name = "") const;
-        msr::airlib::ImuDataBuffer getImuDataBuffer(const std::string& vehicle_name = "") const;
-        msr::airlib::LidarDataBuffer getLidarDataBuffer(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::GpsDataBuffer getGpsDataBuffer(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::ImuDataBuffer getImuDataBuffer(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::LidarDataBuffer getLidarDataBuffer(const std::string& lidar_name = "", const std::string& vehicle_name = "") const;
 
-        Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
+        [[nodiscard]] Pose simGetVehiclePose(const std::string& vehicle_name = "") const;
         void simSetVehiclePose(const Pose& pose, bool ignore_collision, const std::string& vehicle_name = "");
         void simSetTraceLine(const std::vector<float>& color_rgba, float thickness = 3.0f, const std::string& vehicle_name = "");
 
@@ -151,9 +152,9 @@ namespace airlib
         vector<MeshPositionVertexBuffersResponse> simGetMeshPositionVertexBuffers();
         bool simAddVehicle(const std::string& vehicle_name, const std::string& vehicle_type, const Pose& pose, const std::string& pawn_path = "");
 
-        CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
+        [[nodiscard]] CollisionInfo simGetCollisionInfo(const std::string& vehicle_name = "") const;
 
-        CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
+        [[nodiscard]] CameraInfo simGetCameraInfo(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false) const;
         void simSetDistortionParam(const std::string& camera_name, const std::string& param_name, float value, const std::string& vehicle_name = "", bool external = false);
         std::vector<float> simGetDistortionParams(const std::string& camera_name, const std::string& vehicle_name = "", bool external = false);
         void simSetCameraPose(const std::string& camera_name, const Pose& pose, const std::string& vehicle_name = "", bool external = false);
@@ -161,9 +162,9 @@ namespace airlib
         void simSetCameraOrientation(const std::string& camera_name, const Quaternionr& orientation, const std::string& vehicle_name = "", bool external = false);
 
         bool simCreateVoxelGrid(const Vector3r& position, const int& x_size, const int& y_size, const int& z_size, const float& res, const std::string& output_file);
-        msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::Kinematics::State simGetGroundTruthKinematics(const std::string& vehicle_name = "") const;
         void simSetKinematics(const Kinematics::State& state, bool ignore_collision, const std::string& vehicle_name = "");
-        msr::airlib::Environment::State simGetGroundTruthEnvironment(const std::string& vehicle_name = "") const;
+        [[nodiscard]] msr::airlib::Environment::State simGetGroundTruthEnvironment(const std::string& vehicle_name = "") const;
         std::vector<std::string> simSwapTextures(const std::string& tags, int tex_id = 0, int component_id = 0, int material_id = 0);
         bool simSetObjectMaterial(const std::string& object_name, const std::string& material_name, const int component_id = 0);
         bool simSetObjectMaterialFromTexture(const std::string& object_name, const std::string& texture_path, const int component_id = 0);
@@ -176,13 +177,13 @@ namespace airlib
         void simSetWind(const Vector3r& wind) const;
         vector<string> listVehicles();
 
-        std::string getSettingsString() const;
+        [[nodiscard]] std::string getSettingsString() const;
 
-        std::vector<std::string> simListAssets() const;
+        [[nodiscard]] std::vector<std::string> simListAssets() const;
 
     protected:
         void* getClient();
-        const void* getClient() const;
+        [[nodiscard]] const void* getClient() const;
 
     private:
         struct impl;

--- a/AirLib/include/api/VehicleApiBase.hpp
+++ b/AirLib/include/api/VehicleApiBase.hpp
@@ -220,6 +220,14 @@ Some methods may not be applicable to specific vehicle in which case an exceptio
 
             return magnetometer->getOutput();
         }
+        virtual const Vector3r &getMagnetometerGroundTruthMagneticField(const std::string &magnetometer_name) const
+        {
+            auto* magnetometer = static_cast<const MagnetometerBase*>(findSensorByName(magnetometer_name, SensorBase::SensorType::Magnetometer));
+            if (magnetometer == nullptr)
+                throw VehicleControllerException(Utils::stringf("No magnetometer with name %s exist on vehicle", magnetometer_name.c_str()));
+
+            return magnetometer->getGroundTruthMagneticField();
+        }
 
         // Gps API
         virtual const GpsBase::Output& getGpsData(const std::string& gps_name) const

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -15,7 +15,8 @@ namespace airlib
     //velocity
     struct Twist
     {
-        Vector3r linear, angular;
+        Vector3r linear = Vector3r::Zero();
+        Vector3r angular = Vector3r::Zero();
 
         Twist()
         {
@@ -105,8 +106,8 @@ namespace airlib
 
     struct Accelerations
     {
-        Vector3r linear;
-        Vector3r angular;
+        Vector3r linear = Vector3r::Zero();
+        Vector3r angular = Vector3r::Zero();
 
         Accelerations()
         {
@@ -126,8 +127,8 @@ namespace airlib
 
     struct PoseWithCovariance
     {
-        VectorMath::Pose pose;
-        vector<real_T> covariance; //36 elements, 6x6 matrix
+        VectorMath::Pose pose{};
+        vector<real_T> covariance{}; //36 elements, 6x6 matrix
 
         PoseWithCovariance()
             : covariance(36, 0)

--- a/AirLib/include/common/CommonStructs.hpp
+++ b/AirLib/include/common/CommonStructs.hpp
@@ -197,9 +197,9 @@ namespace airlib
 
     struct HomeGeoPoint
     {
-        GeoPoint home_geo_point;
-        double lat_rad, lon_rad;
-        double cos_lat, sin_lat;
+        GeoPoint home_geo_point {};
+        double lat_rad = 0.0, lon_rad = 0.0;
+        double cos_lat = 0.0, sin_lat = 0.0;
 
         HomeGeoPoint()
         {
@@ -239,7 +239,7 @@ namespace airlib
         real_T penetration_depth = 0;
         TTimePoint time_stamp = 0;
         unsigned int collision_count = 0;
-        std::string object_name;
+        std::string object_name {};
         int object_id = -1;
 
         CollisionInfo()
@@ -257,12 +257,13 @@ namespace airlib
 
     struct CameraInfo
     {
-        Pose pose;
-        float fov;
+        Pose pose {};
+        float fov = 0.0;
         ProjectionMatrix proj_mat;
 
         CameraInfo()
         {
+            proj_mat.setTo(0.0);
         }
 
         CameraInfo(const Pose& pose_val, float fov_val, const ProjectionMatrix& proj_mat_val)

--- a/AirLib/include/common/VectorMath.hpp
+++ b/AirLib/include/common/VectorMath.hpp
@@ -99,8 +99,8 @@ namespace airlib
         struct Transform
         {
             EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-            Vector3T translation;
-            QuaternionT rotation;
+            Vector3T translation = Vector3T::Zero();
+            QuaternionT rotation = QuaternionT::Identity();
         };
 
         class RandomVectorT

--- a/AirLib/include/physics/Environment.hpp
+++ b/AirLib/include/physics/Environment.hpp
@@ -21,14 +21,14 @@ namespace airlib
         struct State
         {
             //these fields must be set at initialization time
-            Vector3r position;
-            GeoPoint geo_point;
+            Vector3r position = Vector3r::Zero();
+            GeoPoint geo_point {};
 
             //these fields are computed
-            Vector3r gravity;
-            real_T air_pressure;
-            real_T temperature;
-            real_T air_density;
+            Vector3r gravity = Vector3r::Zero();
+            real_T air_pressure = 0.0;
+            real_T temperature = 0.0;
+            real_T air_density = 0.0;
 
             State()
             {

--- a/AirLib/include/physics/Kinematics.hpp
+++ b/AirLib/include/physics/Kinematics.hpp
@@ -18,9 +18,9 @@ namespace airlib
     public:
         struct State
         {
-            Pose pose;
-            Twist twist;
-            Accelerations accelerations;
+            Pose pose{};
+            Twist twist{};
+            Accelerations accelerations{};
 
             static State zero()
             {

--- a/AirLib/include/physics/Kinematics.hpp
+++ b/AirLib/include/physics/Kinematics.hpp
@@ -102,8 +102,8 @@ namespace airlib
         }
 
     private: //fields
-        State initial_;
-        State current_;
+        State initial_ = State::zero();
+        State current_ = State::zero();
     };
 }
 } //namespace

--- a/AirLib/include/sensors/SensorBase.hpp
+++ b/AirLib/include/sensors/SensorBase.hpp
@@ -41,8 +41,8 @@ namespace airlib
     protected:
         struct GroundTruth
         {
-            const Kinematics::State* kinematics;
-            const Environment* environment;
+            const Kinematics::State* kinematics{};
+            const Environment* environment{};
         };
 
     public:
@@ -54,6 +54,9 @@ namespace airlib
 
         const GroundTruth& getGroundTruth() const
         {
+            if(!ground_truth_.kinematics || !ground_truth_.environment){
+                throw std::runtime_error("Sensor not initialised");
+            }
             return ground_truth_;
         }
 

--- a/AirLib/include/sensors/gps/GpsBase.hpp
+++ b/AirLib/include/sensors/gps/GpsBase.hpp
@@ -94,6 +94,9 @@ namespace airlib
             uint64_t time_utc = 0;
             bool has_yaw = false;
             real_T yaw = 0.f;
+            real_T yaw_uncertainty; // standard deviation in yaw measurement [rad]
+            real_T speed_uncertainty; // standard deviation in speed measurement [m/s]
+            real_T course_uncertainty; // standard deviation in course measurement [rad]
         };
 
         struct NavSatFix

--- a/AirLib/include/sensors/gps/GpsBase.hpp
+++ b/AirLib/include/sensors/gps/GpsBase.hpp
@@ -87,16 +87,16 @@ namespace airlib
 
         struct GnssReport
         {
-            GeoPoint geo_point;
-            real_T eph, epv; //GPS HDOP/VDOP horizontal/vertical dilution of position (unitless), 0-100%
+            GeoPoint geo_point {};
+            real_T eph = 0.0, epv = 0.0; //GPS HDOP/VDOP horizontal/vertical dilution of position (unitless), 0-100%
             Vector3r velocity = Vector3r::Zero();
-            GnssFixType fix_type;
+            GnssFixType fix_type = GNSS_FIX_NO_FIX;
             uint64_t time_utc = 0;
             bool has_yaw = false;
             real_T yaw = 0.f;
-            real_T yaw_uncertainty; // standard deviation in yaw measurement [rad]
-            real_T speed_uncertainty; // standard deviation in speed measurement [m/s]
-            real_T course_uncertainty; // standard deviation in course measurement [rad]
+            real_T yaw_uncertainty = 0.0; // standard deviation in yaw measurement [rad]
+            real_T speed_uncertainty = 0.0; // standard deviation in speed measurement [m/s]
+            real_T course_uncertainty = 0.0; // standard deviation in course measurement [rad]
         };
 
         struct NavSatFix
@@ -109,8 +109,8 @@ namespace airlib
 
         struct Output
         { //same as ROS message
-            TTimePoint time_stamp;
-            GnssReport gnss;
+            TTimePoint time_stamp = 0;
+            GnssReport gnss {};
             bool is_valid = false;
         };
 

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -80,6 +80,7 @@ namespace airlib
             output.gnss.geo_point = ground_truth.environment->getState().geo_point;
             output.gnss.eph = eph;
             output.gnss.epv = epv;
+            std::cout << "GNSS velocity: " << output.gnss.velocity << ", Ground Truth Kinematics Linear: " << ground_truth.kinematics->twist.linear << std::endl;
             output.gnss.velocity = ground_truth.kinematics->twist.linear;
             output.gnss.has_yaw = true;
             real_T pitch, roll, yaw;

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -5,7 +5,6 @@
 #define msr_airlib_Gps_hpp
 
 #include <random>
-#include <algorithm>
 
 #include "common/Common.hpp"
 #include "GpsSimpleParams.hpp"
@@ -88,7 +87,7 @@ namespace airlib
             VectorMath::toEulerianAngle(ground_truth.kinematics->pose.orientation, pitch, roll, yaw);
             output.gnss.yaw = yaw;
             output.gnss.speed_uncertainty = std::max<real_T>(0.04, output.gnss.eph);
-            output.gnss.course_uncertainty = std::clamp<real_T>(output.gnss.eph / output.gnss.velocity.norm(), 0.08, 1e2);
+            output.gnss.course_uncertainty = std::min<real_T>(std::max<real_T>(output.gnss.eph / output.gnss.velocity.norm(), 0.08), 1e2);
 
             output.gnss.fix_type =
                 output.gnss.eph <= params_.eph_min_3d   ? GnssFixType::GNSS_FIX_3D_FIX

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -5,6 +5,8 @@
 #define msr_airlib_Gps_hpp
 
 #include <random>
+#include <algorithm>
+
 #include "common/Common.hpp"
 #include "GpsSimpleParams.hpp"
 #include "GpsBase.hpp"

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -93,7 +93,7 @@ namespace airlib
                 : output.gnss.eph <= params_.eph_min_2d ? GnssFixType::GNSS_FIX_2D_FIX
                                                         : GnssFixType::GNSS_FIX_NO_FIX;
 
-            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.1 : 7.0;
+            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.0001 : 0.01;
 
             output.time_stamp = clock()->nowNanos();
 

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -80,7 +80,6 @@ namespace airlib
             output.gnss.geo_point = ground_truth.environment->getState().geo_point;
             output.gnss.eph = eph;
             output.gnss.epv = epv;
-            std::cout << "GNSS velocity: " << output.gnss.velocity << ", Ground Truth Kinematics Linear: " << ground_truth.kinematics->twist.linear << std::endl;
             output.gnss.velocity = ground_truth.kinematics->twist.linear;
             output.gnss.has_yaw = true;
             real_T pitch, roll, yaw;

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -93,7 +93,7 @@ namespace airlib
                 : output.gnss.eph <= params_.eph_min_2d ? GnssFixType::GNSS_FIX_2D_FIX
                                                         : GnssFixType::GNSS_FIX_NO_FIX;
 
-            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.0001 : 0.01;
+            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.02 : 0.05;
 
             output.time_stamp = clock()->nowNanos();
 

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -85,8 +85,8 @@ namespace airlib
             real_T pitch, roll, yaw;
             VectorMath::toEulerianAngle(ground_truth.kinematics->pose.orientation, pitch, roll, yaw);
             output.gnss.yaw = yaw;
-            output.gnss.speed_uncertainty = 10.0f * output.gnss.eph; // assume update frequency of 10Hz
-            output.gnss.course_uncertainty = std::min<real_T>(10.0f * output.gnss.eph / output.gnss.velocity.norm(), 1e2); // assume update frequency of 10Hz
+            output.gnss.speed_uncertainty = std::max<real_T>(0.04, output.gnss.eph);
+            output.gnss.course_uncertainty = std::clamp<real_T>(output.gnss.eph / output.gnss.velocity.norm(), 0.08, 1e2);
 
             output.gnss.fix_type =
                 output.gnss.eph <= params_.eph_min_3d   ? GnssFixType::GNSS_FIX_3D_FIX

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -85,14 +85,19 @@ namespace airlib
             real_T pitch, roll, yaw;
             VectorMath::toEulerianAngle(ground_truth.kinematics->pose.orientation, pitch, roll, yaw);
             output.gnss.yaw = yaw;
-            output.is_valid = true;
+            output.gnss.speed_uncertainty = 10.0f * output.gnss.eph; // assume update frequency of 10Hz
+            output.gnss.course_uncertainty = std::min<real_T>(10.0f * output.gnss.eph / output.gnss.velocity.norm(), 1e2); // assume update frequency of 10Hz
 
             output.gnss.fix_type =
                 output.gnss.eph <= params_.eph_min_3d   ? GnssFixType::GNSS_FIX_3D_FIX
                 : output.gnss.eph <= params_.eph_min_2d ? GnssFixType::GNSS_FIX_2D_FIX
                                                         : GnssFixType::GNSS_FIX_NO_FIX;
 
+            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.1 : 7.0;
+
             output.time_stamp = clock()->nowNanos();
+
+            output.is_valid = true;
 
             delay_line_.push_back(output);
         }

--- a/AirLib/include/sensors/gps/GpsSimple.hpp
+++ b/AirLib/include/sensors/gps/GpsSimple.hpp
@@ -93,7 +93,7 @@ namespace airlib
                 : output.gnss.eph <= params_.eph_min_2d ? GnssFixType::GNSS_FIX_2D_FIX
                                                         : GnssFixType::GNSS_FIX_NO_FIX;
 
-            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.02 : 0.05;
+            output.gnss.yaw_uncertainty = output.gnss.fix_type > GnssFixType::GNSS_FIX_2D_FIX ? 0.0002 : 0.05;
 
             output.time_stamp = clock()->nowNanos();
 

--- a/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -115,8 +115,8 @@ namespace airlib
 
         struct State
         {
-            Vector3r gyroscope_bias;
-            Vector3r accelerometer_bias;
+            Vector3r gyroscope_bias = Vector3r::Zero();
+            Vector3r accelerometer_bias = Vector3r::Zero();
         } state_;
 
         TTimePoint last_time_;

--- a/AirLib/include/sensors/magnetometer/MagnetometerBase.hpp
+++ b/AirLib/include/sensors/magnetometer/MagnetometerBase.hpp
@@ -41,6 +41,8 @@ namespace airlib
             return output_;
         }
 
+        [[nodiscard]] virtual const Vector3r &getGroundTruthMagneticField() const = 0;
+
     protected:
         void setOutput(const Output& output)
         {

--- a/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
+++ b/AirLib/include/sensors/magnetometer/MagnetometerSimple.hpp
@@ -64,6 +64,13 @@ namespace airlib
         }
         //*** End: UpdatableObject implementation ***//
 
+        //*** Start: MagnetomerBase implementation ***//
+        [[nodiscard]] const Vector3r& getGroundTruthMagneticField() const override
+        {
+            return magnetic_field_true_;
+        }
+        //*** End: MagnetomerBase implementation ***//
+
         virtual ~MagnetometerSimple() = default;
 
     private: //methods
@@ -106,7 +113,7 @@ namespace airlib
         RandomVectorGaussianR noise_vec_;
         Vector3r bias_vec_;
 
-        Vector3r magnetic_field_true_;
+        Vector3r magnetic_field_true_ = Vector3r::Zero();
         MagnetometerSimpleParams params_;
 
         FrequencyLimiter freq_limiter_;

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1209,7 +1209,7 @@ namespace airlib
                     qgc_proxy_ = nullptr;
                 }
                 else {
-                    connection->subscribe([=, this](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
+                    connection->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection_val);
                         processQgcMessages(msg);
                     });
@@ -1314,7 +1314,7 @@ namespace airlib
             }
 
             // start listening to the SITL connection.
-            connection_->subscribe([=, this](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+            connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                 unused(connection);
                 processMavMessages(msg);
             });
@@ -1428,7 +1428,7 @@ namespace airlib
             // listen to this UDP mavlink connection also
             auto mavcon = mav_vehicle_->getConnection();
             if (mavcon != nullptr && mavcon != connection_) {
-                mavcon->subscribe([=,this](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+                mavcon->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                     unused(connection);
                     processControlMessages(msg);
                 });
@@ -1497,7 +1497,7 @@ namespace airlib
                     addStatusMessage(Utils::stringf("Connected to PX4 over serial port: %s", port_name_auto.c_str()));
 
                     // start listening to the HITL connection.
-                    connection_->subscribe([=, this](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+                    connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection);
                         processMavMessages(msg);
                     });

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1209,22 +1209,15 @@ namespace airlib
                     qgc_proxy_ = nullptr;
                 }
                 else {
-#ifdef _WIN32
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+                    connection->subscribe([=
+#if __cplusplus >= 202002L
+                                                ,
+                                            this
 #endif
-                    connection->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
+                    ](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection_val);
                         processQgcMessages(msg);
                     });
-#ifdef _WIN32
-#pragma warning(pop)
-#elif defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
                 }
             }
             return qgc_proxy_ != nullptr;
@@ -1326,22 +1319,15 @@ namespace airlib
             }
 
             // start listening to the SITL connection.
-#ifdef _WIN32
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+            connection_->subscribe([=
+#if __cplusplus >= 202002L
+                                                ,
+                                            this
 #endif
-            connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+            ](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                 unused(connection);
                 processMavMessages(msg);
             });
-#ifdef _WIN32
-#pragma warning(pop)
-#elif defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
             hil_node_ = std::make_shared<mavlinkcom::MavLinkNode>(connection_info_.sim_sysid, connection_info_.sim_compid);
             hil_node_->connect(connection_);
@@ -1452,22 +1438,15 @@ namespace airlib
             // listen to this UDP mavlink connection also
             auto mavcon = mav_vehicle_->getConnection();
             if (mavcon != nullptr && mavcon != connection_) {
-#ifdef _WIN32
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
+                mavcon->subscribe([=
+#if __cplusplus >= 202002L
+                                                ,
+                                            this
 #endif
-                mavcon->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+                ](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                     unused(connection);
                     processControlMessages(msg);
                 });
-#ifdef _WIN32
-#pragma warning(pop)
-#elif defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
             }
             else {
                 mav_vehicle_->connect(connection_);
@@ -1531,23 +1510,16 @@ namespace airlib
                     hil_node_ = std::make_shared<mavlinkcom::MavLinkNode>(connection_info_.sim_sysid, connection_info_.sim_compid);
                     hil_node_->connect(connection_);
                     addStatusMessage(Utils::stringf("Connected to PX4 over serial port: %s", port_name_auto.c_str()));
-#ifdef _WIN32
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#elif defined(__GNUC__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated"
-#endif
                     // start listening to the HITL connection.
-                    connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
+                    connection_->subscribe([=
+#if __cplusplus >= 202002L
+                                                ,
+                                            this
+#endif
+                    ](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection);
                         processMavMessages(msg);
                     });
-#ifdef _WIN32
-#pragma warning(pop)
-#elif defined (__GNUC__)
-#pragma GCC diagnostic pop
-#endif
 
                     mav_vehicle_ = std::make_shared<mavlinkcom::MavLinkVehicle>(connection_info_.vehicle_sysid, connection_info_.vehicle_compid);
 

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1209,10 +1209,22 @@ namespace airlib
                     qgc_proxy_ = nullptr;
                 }
                 else {
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
                     connection->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection_val);
                         processQgcMessages(msg);
                     });
+#ifdef _WIN32
+#pragma warning(pop)
+#elif defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
                 }
             }
             return qgc_proxy_ != nullptr;
@@ -1314,10 +1326,22 @@ namespace airlib
             }
 
             // start listening to the SITL connection.
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
             connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                 unused(connection);
                 processMavMessages(msg);
             });
+#ifdef _WIN32
+#pragma warning(pop)
+#elif defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
             hil_node_ = std::make_shared<mavlinkcom::MavLinkNode>(connection_info_.sim_sysid, connection_info_.sim_compid);
             hil_node_->connect(connection_);
@@ -1428,10 +1452,22 @@ namespace airlib
             // listen to this UDP mavlink connection also
             auto mavcon = mav_vehicle_->getConnection();
             if (mavcon != nullptr && mavcon != connection_) {
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
                 mavcon->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                     unused(connection);
                     processControlMessages(msg);
                 });
+#ifdef _WIN32
+#pragma warning(pop)
+#elif defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
             }
             else {
                 mav_vehicle_->connect(connection_);
@@ -1495,12 +1531,23 @@ namespace airlib
                     hil_node_ = std::make_shared<mavlinkcom::MavLinkNode>(connection_info_.sim_sysid, connection_info_.sim_compid);
                     hil_node_->connect(connection_);
                     addStatusMessage(Utils::stringf("Connected to PX4 over serial port: %s", port_name_auto.c_str()));
-
+#ifdef _WIN32
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
                     // start listening to the HITL connection.
                     connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection);
                         processMavMessages(msg);
                     });
+#ifdef _WIN32
+#pragma warning(pop)
+#elif defined (__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
                     mav_vehicle_ = std::make_shared<mavlinkcom::MavLinkVehicle>(connection_info_.vehicle_sysid, connection_info_.vehicle_compid);
 

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1214,7 +1214,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Werror=deprecated"
 #endif
                     connection->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection_val);
@@ -1331,7 +1331,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Werror=deprecated"
 #endif
             connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                 unused(connection);
@@ -1457,7 +1457,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Werror=deprecated"
 #endif
                 mavcon->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                     unused(connection);
@@ -1536,7 +1536,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Werror=deprecated"
 #endif
                     // start listening to the HITL connection.
                     connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {

--- a/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
+++ b/AirLib/include/vehicles/multirotor/firmwares/mavlink/MavLinkMultirotorApi.hpp
@@ -1214,7 +1214,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=deprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
                     connection->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection_val, const mavlinkcom::MavLinkMessage& msg) {
                         unused(connection_val);
@@ -1331,7 +1331,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=deprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
             connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                 unused(connection);
@@ -1457,7 +1457,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=deprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
                 mavcon->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {
                     unused(connection);
@@ -1536,7 +1536,7 @@ namespace airlib
 #pragma warning(disable : 4996)
 #elif defined(__GNUC__)
 #pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Werror=deprecated"
+#pragma GCC diagnostic ignored "-Wdeprecated"
 #endif
                     // start listening to the HITL connection.
                     connection_->subscribe([=](std::shared_ptr<mavlinkcom::MavLinkConnection> connection, const mavlinkcom::MavLinkMessage& msg) {

--- a/AirLib/src/api/RpcLibClientBase.cpp
+++ b/AirLib/src/api/RpcLibClientBase.cpp
@@ -204,6 +204,11 @@ __pragma(warning(disable : 4239))
             return pimpl_->client.call("getMagnetometerData", magnetometer_name, vehicle_name).as<RpcLibAdaptorsBase::MagnetometerData>().to();
         }
 
+        msr::airlib::Vector3r RpcLibClientBase::getGroundTruthMagneticField(const std::string& magnetometer_name, const std::string& vehicle_name) const
+        {
+            return pimpl_->client.call("getGroundTruthMagneticField", magnetometer_name, vehicle_name).as<RpcLibAdaptorsBase::Vector3r>().to();
+        }
+
         msr::airlib::GpsBase::Output RpcLibClientBase::getGpsData(const std::string& gps_name, const std::string& vehicle_name) const
         {
             return pimpl_->client.call("getGpsData", gps_name, vehicle_name).as<RpcLibAdaptorsBase::GpsData>().to();
@@ -303,8 +308,8 @@ __pragma(warning(disable : 4239))
                                                                RpcLibAdaptorsBase::ImageRequest::from(requests),
                                                                num_images,
                                                                vehicle_name)
-                                                .as<vector<RpcLibAdaptorsBase::ImageResponse>>();
-            
+                                               .as<vector<RpcLibAdaptorsBase::ImageResponse>>();
+
             return RpcLibAdaptorsBase::ImageResponse::to(response_adaptor);
         }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request! -->
<!-- ⚠️⚠️ Do Not Delete This! pull_request_template ⚠️⚠️ -->
<!-- Please read our contribution guidelines: https://microsoft.github.io/AirSim/CONTRIBUTING/ -->

Fixes: #    <!-- add this line for each issue your PR solves. -->
- Added lots of `[[nodiscard]]` where appropriate
- Added getter for the magnetic field ground truth
- Added lots of zero-initialisations in structs to reduce unexpected behaviour on non-Windows platforms
- Added three new fields to GPS data:
    - yaw uncertainty
    - speed uncertainty (uncertainty in the magnitude of velocity)
    - course uncertainty (uncertainty in the bearing of velocity)
- Added pre-processor directives in 'MavLinkMultirotorApi.hpp' where `this` needs to be captured in lambda expressions. These allow for warning-free compatibility with pre- and post-C++20 building, which was not the case before as C++20 deprecated the implicit capture of `this` in lambdas, where C++17 gave a warning on explicit capture.
<!-- Fixes: # -->

## About
Tweaks, fixes and additions to aid testing of an EKF for pose estimation using AirLib to simulate the world.

## How Has This Been Tested?
Tests using AirLib, as well as running AirSim.